### PR TITLE
Added support for specifying test annotations

### DIFF
--- a/charts/camunda-bpm-platform/templates/tests/test-connection.yaml
+++ b/charts/camunda-bpm-platform/templates/tests/test-connection.yaml
@@ -6,6 +6,9 @@ metadata:
     {{- include "camunda-bpm-platform.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": test
+    {{- with .Values.tests.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   containers:
     - name: curl

--- a/charts/camunda-bpm-platform/values.yaml
+++ b/charts/camunda-bpm-platform/values.yaml
@@ -170,3 +170,6 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+tests:
+  annotations: {}


### PR DESCRIPTION
This pull request adds support for specifying test annotations in the values.yaml file.
I made this change to allow for the exclusion of certain security violations flagged by [FairwindsOps/polaris](https://github.com/FairwindsOps/polaris) in the test-connection.yaml file.
These annotations allow for specific security violations to be excluded from the tests.

Please review my changes and let me know if you have any feedback or comments.
Thank you for the review!