### PR TITLE
Bugfix: Include custom labels in deployment pod template

### DIFF
--- a/charts/camunda-bpm-platform/templates/_helpers.tpl
+++ b/charts/camunda-bpm-platform/templates/_helpers.tpl
@@ -36,15 +36,11 @@ Common labels
 {{- define "camunda-bpm-platform.labels" -}}
 helm.sh/chart: {{ include "camunda-bpm-platform.chart" . }}
 {{ include "camunda-bpm-platform.selectorLabels" . }}
+{{ include "camunda-bpm-platform.customLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
-{{- if .Values.commonLabels }}
-{{- range $key, $val := .Values.commonLabels }}
-{{ $key }}: {{ $val | quote }}
-{{- end }}
-{{- end }}
 {{- end }}
 
 {{/*
@@ -53,6 +49,17 @@ Selector labels
 {{- define "camunda-bpm-platform.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "camunda-bpm-platform.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Custom labels
+*/}}
+{{- define "camunda-bpm-platform.customLabels" -}}
+{{- if .Values.commonLabels }}
+{{- range $key, $val := .Values.commonLabels }}
+{{ $key }}: {{ $val | quote }}
+{{- end }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/camunda-bpm-platform/templates/deployment.yaml
+++ b/charts/camunda-bpm-platform/templates/deployment.yaml
@@ -29,6 +29,7 @@ spec:
       {{- end }}
       labels:
         {{- include "camunda-bpm-platform.selectorLabels" . | nindent 8 }}
+        {{- include "camunda-bpm-platform.customLabels" . | nindent 8 }}
     spec:
       {{- with .Values.image.pullSecrets }}
       imagePullSecrets:

--- a/charts/camunda-bpm-platform/values.yaml
+++ b/charts/camunda-bpm-platform/values.yaml
@@ -17,7 +17,7 @@ annotations: {}
 # Custom labels to add to all deployed objects
 commonLabels: {}
 # Example
-#  my-custom-annotation: my-value
+#  my-custom-label: my-value
 
 image:
   repository: camunda/camunda-bpm-platform


### PR DESCRIPTION
Custom labels were not included in created pods. In order to comply with our company's kyverno policies, the custom labels need to be present on all created pods as well.