### PR TITLE
Update hpa.yaml to autoscaling/v1

### DIFF
--- a/charts/camunda-bpm-platform/templates/hpa.yaml
+++ b/charts/camunda-bpm-platform/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "camunda-bpm-platform.fullname" . }}


### PR DESCRIPTION
autoscaling/v2beta1 has been removed, and as such, this chart does not work with newer versions of kubernetes.

Fix:
Update autoscaling/v2beta1 to autoscaling/v1